### PR TITLE
Display job quantities in menu

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -4,10 +4,12 @@ class AccountsController < ApplicationController
   include DateSortable
 
   def show
-    jobs = Job.all
+    jobs = Job.all.where.not(id: associated_job_ids)
     @jobs = RecordGrouper.call(jobs)
 
-    flash[:notice] = 'Kiwis are tiny birds.'
+    @all_jobs_total = @jobs.count
+    @saved_jobs_count = 5
+    @rejected_jobs_count = 5
   end
 
   private

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,20 +1,10 @@
 class AccountsController < ApplicationController
   layout 'account'
 
-  include DateSortable
+  include JobUserCounter
 
   def show
     jobs = Job.all.where.not(id: associated_job_ids)
     @jobs = RecordGrouper.call(jobs)
-
-    @all_jobs_total = @jobs.count
-    @saved_jobs_count = 5
-    @rejected_jobs_count = 5
-  end
-
-  private
-
-  def associated_job_ids
-    Current.user.job_users.map(&:job_id)
   end
 end

--- a/app/controllers/concerns/date_sortable.rb
+++ b/app/controllers/concerns/date_sortable.rb
@@ -1,8 +1,0 @@
-module DateSortable
-  extend ActiveSupport::Concern
-
-  def organize_by_date(jobs)
-    result = jobs.all.group_by { _1.created_at.to_date }
-    result.sort_by { |key, _| key }.reverse
-  end
-end

--- a/app/controllers/concerns/job_user_counter.rb
+++ b/app/controllers/concerns/job_user_counter.rb
@@ -1,0 +1,19 @@
+module JobUserCounter
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :count_job_user_records, only: %i[index show]
+  end
+
+  private
+
+  def count_job_user_records
+    @available_count = Job.all.where.not(id: associated_job_ids).count
+    @saved_count = Current.user.job_users.pluck(:status).count('saved')
+    @rejected_count = Current.user.job_users.pluck(:status).count('rejected')
+  end
+
+  def associated_job_ids
+    Current.user.job_users.map(&:job_id)
+  end
+end

--- a/app/controllers/job/rejects_controller.rb
+++ b/app/controllers/job/rejects_controller.rb
@@ -9,11 +9,13 @@ class Job::RejectsController < ApplicationController
   end
 
   def update
-    job = Job.find(params[:job_id])
-    record = Current.user.job_users.find_or_create_by(job:)
-    record.update(status: :rejected)
-    flash[:notice] = 'Rejected job'
+    @job = Job.find(params[:job_id])
 
-    redirect_to job_path(job)
+    job_user = Current.user.job_users.find_or_create_by(job: @job)
+    job_user.update(status: :rejected)
+
+    @status = job_user.status.to_sym
+
+    flash[:notice] = 'Rejected job'
   end
 end

--- a/app/controllers/job/rejects_controller.rb
+++ b/app/controllers/job/rejects_controller.rb
@@ -1,7 +1,7 @@
 class Job::RejectsController < ApplicationController
   layout 'account'
 
-  include DateSortable
+  include JobUserCounter
 
   def index
     jobs = Current.user.jobs.where(job_users: { status: :rejected })
@@ -13,6 +13,8 @@ class Job::RejectsController < ApplicationController
 
     job_user = Current.user.job_users.find_or_create_by(job: @job)
     job_user.update(status: :rejected)
+
+    count_job_user_records
 
     @status = job_user.status.to_sym
 

--- a/app/controllers/job/saves_controller.rb
+++ b/app/controllers/job/saves_controller.rb
@@ -9,12 +9,13 @@ class Job::SavesController < ApplicationController
   end
 
   def update
-    job = Job.find(params[:job_id])
+    @job = Job.find(params[:job_id])
 
-    record = Current.user.job_users.find_or_create_by!(job:)
-    record.update(status: :saved)
+    job_user = Current.user.job_users.find_or_create_by(job: @job)
+    job_user.update(status: :saved)
+
+    @status = job_user.status.to_sym
+
     flash[:notice] = 'Saved job'
-
-    redirect_to job_path(job)
   end
 end

--- a/app/controllers/job/saves_controller.rb
+++ b/app/controllers/job/saves_controller.rb
@@ -1,7 +1,7 @@
 class Job::SavesController < ApplicationController
   layout 'account'
 
-  include DateSortable
+  include JobUserCounter
 
   def index
     jobs = Current.user.jobs.where(job_users: { status: :saved })
@@ -13,6 +13,8 @@ class Job::SavesController < ApplicationController
 
     job_user = Current.user.job_users.find_or_create_by(job: @job)
     job_user.update(status: :saved)
+
+    count_job_user_records
 
     @status = job_user.status.to_sym
 

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -5,6 +5,8 @@ class JobsController < ApplicationController
 
   layout 'account'
 
+  include JobUserCounter
+
   # GET /jobs or /jobs.json
   def index
     @jobs = Job.all

--- a/app/views/job/rejects/index.html.erb
+++ b/app/views/job/rejects/index.html.erb
@@ -1,19 +1,15 @@
-
-<turbo-frame id="page_body">
-  <div class="mb-10 bg-slate-700 overflow-hidden rounded-lg shadow">
-    <div class="flex min-w-0 gap-x-4 px-4 py-5 sm:p-6">
-      <svg class="fill-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="30px" height="30px">
-        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-      </svg>
-      <div class="min-w-0 flex-auto">
-      <h1 class="text-2xl/8 font-semibold sm:text-xl/8 dark:text-white text-white">Rejected jobs</h1>
-      </div>
+<div class="mb-10 bg-slate-700 overflow-hidden rounded-lg shadow">
+  <div class="flex min-w-0 gap-x-4 px-4 py-5 sm:p-6">
+    <svg class="fill-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="30px" height="30px">
+      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+    </svg>
+    <div class="min-w-0 flex-auto">
+    <h1 class="text-2xl/8 font-semibold sm:text-xl/8 dark:text-white text-white">Rejected jobs</h1>
     </div>
   </div>
+</div>
 
+<p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've rejected.</p>
+<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
 
-  <p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've rejected.</p>
-  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
-
-  <%= render "shared/job_list", locals: { jobs: @jobs } %>
-</turbo-frame>
+<%= render "shared/job_list", locals: { jobs: @jobs } %>

--- a/app/views/job/rejects/update.turbo_stream.erb
+++ b/app/views/job/rejects/update.turbo_stream.erb
@@ -1,7 +1,1 @@
-<%= turbo_stream.replace "status" do %>
-  <%= render "jobs/status", status: @status %>
-<% end %>
-
-<%= turbo_stream.replace "action" do %>
-  <%= render "jobs/action", job: @job, status: @status %>
-<% end %>
+<%= render partial: "shared/job_show_streams", formats: [:html] %>

--- a/app/views/job/rejects/update.turbo_stream.erb
+++ b/app/views/job/rejects/update.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace "status" do %>
+  <%= render "jobs/status", status: @status %>
+<% end %>
+
+<%= turbo_stream.replace "action" do %>
+  <%= render "jobs/action", job: @job, status: @status %>
+<% end %>

--- a/app/views/job/saves/index.html.erb
+++ b/app/views/job/saves/index.html.erb
@@ -1,17 +1,15 @@
-<turbo-frame id="page_body">
-  <div class="mb-10 bg-slate-700 overflow-hidden rounded-lg shadow">
-    <div class="flex min-w-0 gap-x-4 px-4 py-5 sm:p-6">
-      <svg class="fill-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="30px" height="30px">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
-      </svg>
-      <div class="min-w-0 flex-auto">
-      <h1 class="text-2xl/8 font-semibold text-white sm:text-xl/8 dark:text-white">Saved jobs</h1>
-      </div>
+<div class="mb-10 bg-slate-700 overflow-hidden rounded-lg shadow">
+  <div class="flex min-w-0 gap-x-4 px-4 py-5 sm:p-6">
+    <svg class="fill-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="30px" height="30px">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
+    </svg>
+    <div class="min-w-0 flex-auto">
+    <h1 class="text-2xl/8 font-semibold text-white sm:text-xl/8 dark:text-white">Saved jobs</h1>
     </div>
   </div>
+</div>
 
-  <p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've saved.</p>
-  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+<p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've saved.</p>
+<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
 
-  <%= render "shared/job_list", locals: { jobs: @jobs } %>
-</turbo-frame>
+<%= render "shared/job_list", locals: { jobs: @jobs } %>

--- a/app/views/job/saves/update.turbo_stream.erb
+++ b/app/views/job/saves/update.turbo_stream.erb
@@ -1,7 +1,1 @@
-<%= turbo_stream.replace "status" do %>
-  <%= render "jobs/status", status: @status %>
-<% end %>
-
-<%= turbo_stream.replace "action" do %>
-  <%= render "jobs/action", job: @job, status: @status %>
-<% end %>
+<%= render partial: "shared/job_show_streams", formats: [:html] %>

--- a/app/views/job/saves/update.turbo_stream.erb
+++ b/app/views/job/saves/update.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace "status" do %>
+  <%= render "jobs/status", status: @status %>
+<% end %>
+
+<%= turbo_stream.replace "action" do %>
+  <%= render "jobs/action", job: @job, status: @status %>
+<% end %>

--- a/app/views/jobs/_action.html.erb
+++ b/app/views/jobs/_action.html.erb
@@ -1,8 +1,10 @@
-<% if status == :saved %>
-    <%= button_to "Reject job", job_reject_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
-<% elsif status == :rejected %>
-    <%= button_to "Save job", job_safe_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
-<% else %>
-  <%= button_to "Reject job", job_reject_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
-  <%= button_to "Save job", job_safe_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
-<% end %>
+<div id="action" class="flex gap-x-6">
+  <% if status == :saved %>
+      <%= button_to "Reject job", job_reject_path(job_id: job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+  <% elsif status == :rejected %>
+      <%= button_to "Save job", job_safe_path(job_id: job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+  <% else %>
+    <%= button_to "Reject job", job_reject_path(job_id: job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+    <%= button_to "Save job", job_safe_path(job_id: job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+  <% end %>
+</div>

--- a/app/views/jobs/_action.html.erb
+++ b/app/views/jobs/_action.html.erb
@@ -1,0 +1,8 @@
+<% if status == :saved %>
+    <%= button_to "Reject job", job_reject_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+<% elsif status == :rejected %>
+    <%= button_to "Save job", job_safe_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+<% else %>
+  <%= button_to "Reject job", job_reject_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+  <%= button_to "Save job", job_safe_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
+<% end %>

--- a/app/views/jobs/_status.html.erb
+++ b/app/views/jobs/_status.html.erb
@@ -1,15 +1,17 @@
-<% if status == :saved %>
-  <span class="inline-flex items-center gap-x-1.5 rounded-full px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200">
-    <svg class="size-1.5 fill-green-500" viewBox="0 0 6 6" aria-hidden="true">
-      <circle cx="3" cy="3" r="3" />
-    </svg>
-    Saved
-  </span>
-<% elsif status == :rejected  %>
-  <span class="inline-flex items-center gap-x-1.5 rounded-full px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200">
-    <svg class="size-1.5 fill-red-500" viewBox="0 0 6 6" aria-hidden="true">
-      <circle cx="3" cy="3" r="3" />
-    </svg>
-    Rejected
-  </span>
-<% end %>
+<div id="status">
+  <% if status == :saved %>
+    <span class="inline-flex items-center gap-x-1.5 rounded-full px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200">
+      <svg class="size-1.5 fill-green-500" viewBox="0 0 6 6" aria-hidden="true">
+        <circle cx="3" cy="3" r="3" />
+      </svg>
+      Saved
+    </span>
+  <% elsif status == :rejected  %>
+    <span class="inline-flex items-center gap-x-1.5 rounded-full px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200">
+      <svg class="size-1.5 fill-red-500" viewBox="0 0 6 6" aria-hidden="true">
+        <circle cx="3" cy="3" r="3" />
+      </svg>
+      Rejected
+    </span>
+  <% end %>
+</div>

--- a/app/views/jobs/_status.html.erb
+++ b/app/views/jobs/_status.html.erb
@@ -1,0 +1,15 @@
+<% if status == :saved %>
+  <span class="inline-flex items-center gap-x-1.5 rounded-full px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200">
+    <svg class="size-1.5 fill-green-500" viewBox="0 0 6 6" aria-hidden="true">
+      <circle cx="3" cy="3" r="3" />
+    </svg>
+    Saved
+  </span>
+<% elsif status == :rejected  %>
+  <span class="inline-flex items-center gap-x-1.5 rounded-full px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200">
+    <svg class="size-1.5 fill-red-500" viewBox="0 0 6 6" aria-hidden="true">
+      <circle cx="3" cy="3" r="3" />
+    </svg>
+    Rejected
+  </span>
+<% end %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -1,26 +1,23 @@
-
-<turbo-frame id="page_body">
-  <div class="flex min-w-0 gap-x-4">
-    <img class="h-12 w-12 flex-none rounded-full bg-gray-50" src="<%= logo_helper(company_name: @job.company_name) %>" alt="">
-    <div class="min-w-0 flex-auto space-y-2">
-    <h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white"><%= @job.title %></h1>
-      <div class="flex space-x-2">
-        <div>
-          <%= @job.company_name %>
-        </div>
-        <%= render "status", status: @status %>
+<div class="flex min-w-0 gap-x-4">
+  <img class="h-12 w-12 flex-none rounded-full bg-gray-50" src="<%= logo_helper(company_name: @job.company_name) %>" alt="">
+  <div class="min-w-0 flex-auto space-y-2">
+  <h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white"><%= @job.title %></h1>
+    <div class="flex space-x-2">
+      <div>
+        <%= @job.company_name %>
       </div>
-      <p class="mt-1 text-xs leading-5 text-gray-500">Posted <%= @job.created_at.strftime("%-d %b, %Y, %-l:%M%P") %></p>
+      <%= render "status", status: @status %>
     </div>
+    <p class="mt-1 text-xs leading-5 text-gray-500">Posted <%= @job.created_at.strftime("%-d %b, %Y, %-l:%M%P") %></p>
   </div>
+</div>
 
-  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
 
-  <p><%= Faker::Quote.matz %></p>
+<p><%= Faker::Quote.matz %></p>
 
-  <div class="mt-6 flex items-center justify-end gap-x-6">
-    <%= link_to "Back to jobs", account_path, data: {turbo_frame: "_top"}, class: "text-sm font-semibold leading-6 text-gray-900" %>
+<div class="mt-6 flex items-center justify-end gap-x-6">
+  <%= link_to "Back to jobs", account_path, class: "text-sm font-semibold leading-6 text-gray-900" %>
 
-    <%= render "action", job: @job, status: @status %>
-  </div>
-</turbo-frame>
+  <%= render "action", job: @job, status: @status %>
+</div>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -21,6 +21,6 @@
   <div class="mt-6 flex items-center justify-end gap-x-6">
     <%= link_to "Back to jobs", account_path, data: {turbo_frame: "_top"}, class: "text-sm font-semibold leading-6 text-gray-900" %>
 
-    <%= render "action", status: @status %>
+    <%= render "action", job: @job, status: @status %>
   </div>
 </turbo-frame>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -8,21 +8,7 @@
         <div>
           <%= @job.company_name %>
         </div>
-        <% if @status == :saved %>
-          <span class="inline-flex items-center gap-x-1.5 rounded-full px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200">
-            <svg class="size-1.5 fill-green-500" viewBox="0 0 6 6" aria-hidden="true">
-              <circle cx="3" cy="3" r="3" />
-            </svg>
-            Saved
-          </span>
-        <% elsif @status == :rejected  %>
-          <span class="inline-flex items-center gap-x-1.5 rounded-full px-2 py-1 text-xs font-medium text-gray-900 ring-1 ring-inset ring-gray-200">
-            <svg class="size-1.5 fill-red-500" viewBox="0 0 6 6" aria-hidden="true">
-              <circle cx="3" cy="3" r="3" />
-            </svg>
-            Rejected
-          </span>
-        <% end %>
+        <%= render "status", status: @status %>
       </div>
       <p class="mt-1 text-xs leading-5 text-gray-500">Posted <%= @job.created_at.strftime("%-d %b, %Y, %-l:%M%P") %></p>
     </div>
@@ -35,13 +21,6 @@
   <div class="mt-6 flex items-center justify-end gap-x-6">
     <%= link_to "Back to jobs", account_path, data: {turbo_frame: "_top"}, class: "text-sm font-semibold leading-6 text-gray-900" %>
 
-    <% if @status == :saved %>
-        <%= button_to "Reject job", job_reject_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
-    <% elsif @status == :rejected %>
-        <%= button_to "Save job", job_safe_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
-    <% else %>
-      <%= button_to "Reject job", job_reject_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
-      <%= button_to "Save job", job_safe_path(job_id: @job.id), method: :patch, class: "rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
-    <% end %>
+    <%= render "action", status: @status %>
   </div>
 </turbo-frame>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="flash-notification">
+<div id="flash" data-controller="flash-notification">
   <% if flash[:notice] || flash[:alert] %>
     <div
       class="hidden relative z-50"

--- a/app/views/layouts/account.html.erb
+++ b/app/views/layouts/account.html.erb
@@ -83,14 +83,18 @@
                   <ul role="list" class="flex flex-1 flex-col gap-y-7">
                     <li>
                       <ul role="list" class="-mx-2 space-y-1">
-                        <li>
+                        <li class="flex justify-between">
                           <%= link_to account_path, class: "group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-700 hover:bg-gray-50 hover:text-indigo-600" do %>
                             <svg class="h-6 w-6 shrink-0 text-gray-400 group-hover:text-indigo-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                               <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
                             </svg>
-                              All
-                            </a>
+                            All
                           <% end %>
+                          <div>
+                            <p id="available_count_mobile" class="rounded-full bg-indigo-600/10 px-2.5 py-1 text-xs/5 font-semibold text-indigo-600">
+                              <%= @available_count %>
+                            </p>
+                          </div>
                         </li>
                       </ul>
                     </li>
@@ -98,14 +102,18 @@
                   <ul role="list" class="flex flex-1 flex-col gap-y-7">
                     <li>
                       <ul role="list" class="-mx-2 space-y-1">
-                        <li>
+                        <li class="flex justify-between">
                           <%= link_to job_saves_path, class: "group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-700 hover:bg-gray-50 hover:text-indigo-600" do %>
                             <svg class="h-6 w-6 shrink-0 text-gray-400 group-hover:text-indigo-600"  fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
                               <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
                             </svg>
                               Saved
-                            </a>
                           <% end %>
+                          <div>
+                            <p id="saved_count_mobile" class="saved_count rounded-full bg-indigo-600/10 px-2.5 py-1 text-xs/5 font-semibold text-indigo-600">
+                              <%= @saved_count %>
+                            </p>
+                          </div>
                         </li>
                       </ul>
                     </li>
@@ -113,14 +121,18 @@
                   <ul role="list" class="flex flex-1 flex-col gap-y-7">
                     <li>
                       <ul role="list" class="-mx-2 space-y-1">
-                        <li>
+                        <li class="flex justify-between">
                           <%= link_to job_rejects_path, class: "group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-700 hover:bg-gray-50 hover:text-indigo-600" do %>
                             <svg class="h-6 w-6 shrink-0 text-gray-400 group-hover:text-indigo-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
                               <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
                             </svg>
-                              Rejected
-                            </a>
+                            Rejected
                           <% end %>
+                          <div>
+                            <p class="rejected_count_mobile rounded-full bg-indigo-600/10 px-2.5 py-1 text-xs/5 font-semibold text-indigo-600">
+                              <%= @rejected_count %>
+                            </p>
+                          </div>
                         </li>
                       </ul>
                     </li>
@@ -187,14 +199,17 @@
                   <ul role="list" class="flex flex-1 flex-col gap-y-7">
                     <li>
                       <ul role="list" class="-mx-2 space-y-1">
-                        <li>
+                        <li class="flex justify-between">
                           <%= link_to account_path, class: "group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-700 hover:bg-gray-50 hover:text-indigo-600" do %>
                             <svg class="h-6 w-6 shrink-0 text-gray-400 group-hover:text-indigo-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                               <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
                             </svg>
                               All
-                            </a>
                           <% end %>
+                          <div>
+                            <p id="available_count" class="rounded-full bg-indigo-600/10 px-2.5 py-1 text-xs/5 font-semibold text-indigo-600">
+                              <%= @available_count %></p>
+                          </div>
                         </li>
                       </ul>
                     </li>
@@ -202,14 +217,18 @@
                   <ul role="list" class="flex flex-1 flex-col gap-y-7">
                     <li>
                       <ul role="list" class="-mx-2 space-y-1">
-                        <li>
+                        <li class="flex justify-between">
                           <%= link_to job_saves_path, class: "group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-700 hover:bg-gray-50 hover:text-indigo-600" do %>
                             <svg class="h-6 w-6 shrink-0 text-gray-400 group-hover:text-indigo-600"  fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
                               <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
                             </svg>
                               Saved
-                            </a>
                           <% end %>
+                          <div>
+                            <p id="saved_count" class="rounded-full bg-indigo-600/10 px-2.5 py-1 text-xs/5 font-semibold text-indigo-600">
+                              <%= @saved_count %>
+                            </p>
+                          </div>
                         </li>
                       </ul>
                     </li>
@@ -217,14 +236,18 @@
                   <ul role="list" class="flex flex-1 flex-col gap-y-7">
                     <li>
                       <ul role="list" class="-mx-2 space-y-1">
-                        <li>
+                        <li class="flex justify-between">
                           <%= link_to job_rejects_path, class: "group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-700 hover:bg-gray-50 hover:text-indigo-600" do %>
                             <svg class="h-6 w-6 shrink-0 text-gray-400 group-hover:text-indigo-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
                               <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
                             </svg>
-                              Rejected
-                            </a>
+                            Rejected
                           <% end %>
+                          <div>
+                            <p id="rejected_count" class="rejected_count rounded-full bg-indigo-600/10 px-2.5 py-1 text-xs/5 font-semibold text-indigo-600">
+                              <%= @rejected_count %>
+                            </p>
+                          </div>
                         </li>
                       </ul>
                     </li>

--- a/app/views/shared/_job_show_streams.html.erb
+++ b/app/views/shared/_job_show_streams.html.erb
@@ -5,3 +5,7 @@
 <%= turbo_stream.replace "action" do %>
   <%= render "jobs/action", job: @job, status: @status %>
 <% end %>
+
+<%= turbo_stream.update "flash" do %>
+  <%= render "layouts/flash" %>
+<% end %>

--- a/app/views/shared/_job_show_streams.html.erb
+++ b/app/views/shared/_job_show_streams.html.erb
@@ -9,3 +9,27 @@
 <%= turbo_stream.update "flash" do %>
   <%= render "layouts/flash" %>
 <% end %>
+
+<%= turbo_stream.update "available_count" do %>
+  <%= @available_count %>
+<% end %>
+
+<%= turbo_stream.update "available_count_mobile" do %>
+  <%= @available_count %>
+<% end %>
+
+<%= turbo_stream.update "saved_count" do %>
+  <%= @saved_count %>
+<% end %>
+
+<%= turbo_stream.update "save_count_mobile" do %>
+  <%= @save_count %>
+<% end %>
+
+<%= turbo_stream.update "rejected_count" do %>
+  <%= @rejected_count %>
+<% end %>
+
+<%= turbo_stream.update "rejected_count_mobile" do %>
+  <%= @rejected_count %>
+<% end %>

--- a/app/views/shared/_job_show_streams.html.erb
+++ b/app/views/shared/_job_show_streams.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace "status" do %>
+  <%= render "jobs/status", status: @status %>
+<% end %>
+
+<%= turbo_stream.replace "action" do %>
+  <%= render "jobs/action", job: @job, status: @status %>
+<% end %>


### PR DESCRIPTION
This PR contains a lot of changes to enable turbo-stream responses from the saved & rejected controllers to the job show page. Notably, in the last commit, I removed the turbo-frames I added earlier to the saved & rejected index pages & job show page because they prevent the URL from changing and are redundantt now streams are in place. 