### PR TITLE
bundle lock --add-platform x86_64-linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.6)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -258,6 +260,8 @@ GEM
     stringio (3.1.0)
     tailwindcss-rails (2.7.3-arm64-darwin)
       railties (>= 7.0.0)
+    tailwindcss-rails (2.7.3-x86_64-linux)
+      railties (>= 7.0.0)
     thor (1.3.1)
     timeout (0.4.1)
     turbo-rails (2.0.5)
@@ -286,6 +290,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   authentication-zero (~> 3.0)


### PR DESCRIPTION
Set operating system for Heroku