### PR TITLE
Faker gem available globally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri mingw x64_mingw ]
   gem 'factory_bot_rails'
-  gem 'faker'
   gem 'rspec-rails'
   gem 'pry-rails'
   gem 'pry-byebug'
@@ -94,3 +93,6 @@ end
 gem "bcrypt", "~> 3.1.7"
 
 gem "tailwindcss-rails", "~> 2.7"
+
+# Make avaible to production & development
+gem 'faker'


### PR DESCRIPTION
Make Faker gem available globally.

The production show page broke because it uses Faker to generate placeholder text, but the gem was only available in the development. This change makes the available globally.  
