### PR TITLE
Sidekiq procfile worker and initializer

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -c 2

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,13 @@
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: ENV['REDIS_URL'],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: ENV['REDIS_URL'],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end


### PR DESCRIPTION
Adds a Procfile, which Heroku will use to create web/worker processes and an initializer for Sidekiq. 
The initializer is required for Sidekiq to work in production.