### PR TITLE
Job script improvements

### DIFF
--- a/app/services/index_pages/doors_open.rb
+++ b/app/services/index_pages/doors_open.rb
@@ -14,6 +14,8 @@ module IndexPages
       # Navigate to the target index
       browser.goto 'https://www.doorsopen.co/jobs/?q=&l=London%2C+UK'
 
+      browser.div(id: 'cookiescript_reject').click if browser.div(id: 'cookiescript_reject').present?
+
       # Loop to click the "Load more" button until it disappears
       while browser.button(visible_text: 'Load more').exists?
         browser.button(visible_text: 'Load more').click

--- a/app/services/show_pages/broadwick.rb
+++ b/app/services/show_pages/broadwick.rb
@@ -23,13 +23,12 @@ module ShowPages
         sleep rand(150)
         response = HTTParty.get(url)
 
-        # Parsing the HTML document returned by the server
-        doc = Nokogiri::HTML(response.body)
-
-        # Extract title
-        title = doc.title
-
         if response.code == 200
+          # Parsing the HTML document returned by the server
+          doc = Nokogiri::HTML(response.body)
+
+          # Extract title
+          title = doc.title
 
           # Return object when successful
           return Result.new(

--- a/app/services/show_pages/doors_open.rb
+++ b/app/services/show_pages/doors_open.rb
@@ -23,13 +23,12 @@ module ShowPages
         sleep rand(300)
         response = HTTParty.get(url)
 
-        # Parsing the HTML document returned by the server
-        doc = Nokogiri::HTML(response.body)
-
-        # Extract title
-        title = doc.css('.details-header__title').text.strip
-
         if response.code == 200
+          # Parsing the HTML document returned by the server
+          doc = Nokogiri::HTML(response.body)
+
+          # Extract title
+          title = doc.css('.details-header__title').text.strip
 
           # Return object when successful
           return Result.new(

--- a/lib/tasks/scrape_tasks.rake
+++ b/lib/tasks/scrape_tasks.rake
@@ -3,7 +3,9 @@
 namespace :scrape_tasks do
   desc 'Scrape show pages'
   task scrape_show_pages: :environment do
-    JobShow.all.each { ScrapeJobShowJob.perform_async(_1.id) }
+    job_urls = Job.all.pluck(:url)
+    pages_to_scrape = JobShow.where.not(url: job_urls)
+    pages_to_scrape.each { ScrapeJobShowJob.perform_async(_1.id) }
   end
 
   desc 'Scrape index pages'

--- a/spec/lib/tasks/scrape_tasks.rake
+++ b/spec/lib/tasks/scrape_tasks.rake
@@ -1,0 +1,37 @@
+# spec/tasks/scrape_show_pages_rake_spec.rb
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'scrape_tasks:scrape_show_pages', type: :task do
+  before :all do
+    Rake.application.rake_require('tasks/scrape_tasks')
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task) { Rake::Task['scrape_tasks:scrape_show_pages'] }
+
+  before do
+    task.reenable # Allows the task to be re-run in the same spec
+  end
+
+  describe 'scrape_show_pages' do
+    let!(:job1) { create(:job, url: 'https://example.com/job1') }
+    let!(:job2) { create(:job, url: 'https://example.com/job2') }
+    let!(:job_show1) { create(:JobShow, url: 'https://example.com/job1') }
+    let!(:job_show2) { create(:JobShow, url: 'https://example.com/job2') }
+    let!(:job_show3) { create(:JobShow, url: 'https://example.com/job3') }
+
+    it 'enqueues ScrapeJobShowJob for JobShow records not saved as Job' do
+      expect(ScrapeJobShowJob).to receive(:perform_async).with(job_show3.id).once
+
+      task.invoke
+    end
+
+    it 'does not enqueue if JobShow URL has been saved as Job' do
+      expect(ScrapeJobShowJob).not_to receive(:perform_async).with(job_show1.id)
+      expect(ScrapeJobShowJob).not_to receive(:perform_async).with(job_show2.id)
+
+      task.invoke
+    end
+  end
+end

--- a/spec/services/save_job_spec.rb
+++ b/spec/services/save_job_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SaveJob, type: :model do
   let(:attributes) { OpenStruct.new(company_name: 'NVS', title: 'Ticketing Manager', url: 'doorsopen/first_job') }
   describe 'when given new attributes' do
-    it 'creates a new job record' do
+    it 'creates a new job' do
       expect { described_class.call(attributes) }
         .to change(Job, :count).by(1)
     end
@@ -13,7 +13,7 @@ RSpec.describe SaveJob, type: :model do
 
   describe 'when given existing attributes' do
     before { Job.create(company_name: 'job record', title: 'that exists already', url: 'doorsopen/first_job') }
-    it 'finds and updates the job' do
+    it 'does not create a new job' do
       expect { described_class.call(attributes) }
         .to change(Job, :count).by(0)
     end


### PR DESCRIPTION
This PR updates the `scrape show_pages` task to only enquiries Sidekiq workers for Job Show URLs that have not been persisted as `Job` records.