### PR TITLE
Heroku scheduler task setup

### DIFF
--- a/app/sidekiq/scrape_show.rb
+++ b/app/sidekiq/scrape_show.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Queues up a
-class ScrapeJobShowJob
+class ScrapeShow
   include Sidekiq::Job
 
   def perform(id)

--- a/lib/tasks/scrape_tasks.rake
+++ b/lib/tasks/scrape_tasks.rake
@@ -1,17 +1,27 @@
 # frozen_string_literal: true
 
-namespace :scrape_tasks do
-  desc 'Scrape show pages'
-  task scrape_show_pages: :environment do
-    job_urls = Job.all.pluck(:url)
-    pages_to_scrape = JobShow.where.not(url: job_urls)
-    pages_to_scrape.each { ScrapeJobShowJob.perform_async(_1.id) }
-  end
-
+namespace :tasks do
   desc 'Scrape index pages'
   task scrape_index_pages: :environment do
     IndexPages.constants.each do |index_page|
       Object.const_get("IndexPages::#{index_page}").call
+    end
+  end
+
+  desc 'Scrape show pages'
+  task scrape_show_pages: :environment do
+    if Rails.env.production?
+      system('heroku ps:scale worker=1')
+      puts 'Worker up'
+    end
+
+    job_urls = Job.all.pluck(:url)
+    pages_to_scrape = JobShow.where.not(url: job_urls)
+    pages_to_scrape.each { ScrapeShow.perform_async(_1.id) }
+
+    if Rails.env.production?
+      system('heroku ps:scale worker=0')
+      puts 'Worker down'
     end
   end
 end

--- a/spec/lib/tasks/scrape_tasks.rake
+++ b/spec/lib/tasks/scrape_tasks.rake
@@ -21,15 +21,15 @@ RSpec.describe 'scrape_tasks:scrape_show_pages', type: :task do
     let!(:job_show2) { create(:JobShow, url: 'https://example.com/job2') }
     let!(:job_show3) { create(:JobShow, url: 'https://example.com/job3') }
 
-    it 'enqueues ScrapeJobShowJob for JobShow records not saved as Job' do
-      expect(ScrapeJobShowJob).to receive(:perform_async).with(job_show3.id).once
+    it 'enqueues ScrapeShow for JobShow records not saved as Job' do
+      expect(ScrapeShow).to receive(:perform_async).with(job_show3.id).once
 
       task.invoke
     end
 
     it 'does not enqueue if JobShow URL has been saved as Job' do
-      expect(ScrapeJobShowJob).not_to receive(:perform_async).with(job_show1.id)
-      expect(ScrapeJobShowJob).not_to receive(:perform_async).with(job_show2.id)
+      expect(ScrapeShow).not_to receive(:perform_async).with(job_show1.id)
+      expect(ScrapeShow).not_to receive(:perform_async).with(job_show2.id)
 
       task.invoke
     end

--- a/spec/sidekiq/scrape_job_show_job_spec.rb
+++ b/spec/sidekiq/scrape_job_show_job_spec.rb
@@ -14,7 +14,7 @@ end
 # Tests the show page job. The call to the
 # show page script is stubs to avoid calling
 # out to a real website.
-RSpec.describe ScrapeJobShowJob, type: :job do
+RSpec.describe ScrapeShow, type: :job do
   include ActiveSupport::Testing::TimeHelpers
 
   describe '#perform' do


### PR DESCRIPTION
Update task names and scale up/down Heroku worker as part of the task to scrape show pages.