### PR TITLE
Rename migration to update Jobs table with employer and location columns

### DIFF
--- a/db/migrate/20250124155420_add_html_location_employer_to_jobs.rb
+++ b/db/migrate/20250124155420_add_html_location_employer_to_jobs.rb
@@ -1,4 +1,4 @@
-class AddTextColumnForHtmlToJob < ActiveRecord::Migration[7.2]
+class AddHtmlLocationEmployerToJobs < ActiveRecord::Migration[7.2]
   def change
     add_column :jobs, :employer, :string
     add_column :jobs, :location, :string


### PR DESCRIPTION
Migration was named incorrectly so it failed to run.