### PR TITLE
Prep jobshow and job for employer model

### DIFF
--- a/app/helpers/logo_helper.rb
+++ b/app/helpers/logo_helper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module LogoHelper
-  def logo_helper(company_name:)
-    file_path = Rails.root.join("app/assets/images/logos/#{company_name.downcase}.jpg")
+  def logo_helper(board:)
+    file_path = Rails.root.join("app/assets/images/logos/#{board.downcase}.jpg")
 
     if File.exist?(file_path)
-      image_path("logos/#{company_name.downcase}.jpg")
+      image_path("logos/#{board.downcase}.jpg")
     else
       image_path("logos/default.jpg")
     end

--- a/app/models/job_show.rb
+++ b/app/models/job_show.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class JobShow < ApplicationRecord
-  validates :company, :url, :script, presence: true
+  validates :board, :url, :script, presence: true
 end

--- a/app/services/index_pages/broadwick.rb
+++ b/app/services/index_pages/broadwick.rb
@@ -17,7 +17,7 @@ module IndexPages
       # Find and save jobs
       browser.elements(class_name: 'whr-item').each do |job|
         JobShow.find_or_create_by(
-          company: 'Broadwick',
+          board: 'Broadwick',
           url: job.a.href,
           script: ShowPages::Broadwick.name
         )

--- a/app/services/index_pages/doors_open.rb
+++ b/app/services/index_pages/doors_open.rb
@@ -26,7 +26,7 @@ module IndexPages
 
       browser.elements(tag_name: 'article').each do |article|
         JobShow.find_or_create_by(
-          company: 'DoorsOpen',
+          board: 'DoorsOpen',
           url: article.a.href,
           script: ShowPages::DoorsOpen.name
         )

--- a/app/services/save_job.rb
+++ b/app/services/save_job.rb
@@ -7,10 +7,9 @@ class SaveJob
 
     # Update with latest attributes
     job.update(
-      company_name: attributes.company_name,
+      board: attributes.board,
       url: attributes.url,
       title: attributes.title,
-      employer: attributes.employer,
       location: attributes.location,
       html_content: attributes.html_content
     )

--- a/app/views/job/_job.html.erb
+++ b/app/views/job/_job.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id job %>">
   <p>
     <strong>Company name:</strong>
-    <%= job.company_name %>
+    <%= job.board %>
   </p>
 
   <p>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <div class="flex gap-x-4 py-6 w-full">
-  <img class="h-12 w-12 flex-none rounded-full bg-gray-50" src="<%= logo_helper(company_name: "Broadwick") %>" alt="">
+  <img class="h-12 w-12 flex-none rounded-full bg-gray-50" src="<%= logo_helper(board: @job.board) %>" alt="">
   <div class="flex items-center">
     <h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white"><%= @job.title %></h1>
   </div>
@@ -15,7 +15,7 @@
 <div class="flex justify-between">
   <div class="flex-auto">
     <div class="flex items-start gap-x-3">
-      <div class="text-sm/6 font-medium text-gray-900"> <%= @job.employer %></div>
+      <div class="text-sm/6 font-medium text-gray-900"> <%= @job.employer.name %></div>
       <%= render "status", status: @status %>
     </div>
     <div class="mt-1 text-xs/5 text-gray-500"><%= @job.location %></div>

--- a/app/views/shared/_job_list.html.erb
+++ b/app/views/shared/_job_list.html.erb
@@ -9,14 +9,14 @@
             <%= link_to job_path(job) do %>
               <li class="relative flex justify-between gap-x-6 py-5">
                 <div class="flex min-w-0 gap-x-4">
-                  <img class="h-12 w-12 flex-none rounded-full bg-gray-50" src="<%= logo_helper(company_name: job.company_name) %>" alt="">
+                  <img class="h-12 w-12 flex-none rounded-full bg-gray-50" src="<%= logo_helper(board: job.board) %>" alt="">
                   <div class="min-w-0 flex-auto">
                     <p class="text-sm font-semibold leading-6 text-gray-900">
                         <span class="absolute inset-x-0 -top-px bottom-0"></span>
                         <%= job.title%>
                     </p>
                     <p class="mt-1 flex text-xs leading-5 text-gray-500">
-                      <%= job.company_name %>
+                      <%= job.board %>
                     </p>
                   </div>
                 </div>

--- a/db/migrate/20250223162445_rename_job_show_company_to_board.rb
+++ b/db/migrate/20250223162445_rename_job_show_company_to_board.rb
@@ -1,0 +1,5 @@
+class RenameJobShowCompanyToBoard < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :job_shows, :company, :board
+  end
+end

--- a/db/migrate/20250223174401_remove_employer_from_job.rb
+++ b/db/migrate/20250223174401_remove_employer_from_job.rb
@@ -1,0 +1,6 @@
+class RemoveEmployerFromJob < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :jobs, :employer, :string
+    rename_column :jobs, :company_name, :board
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_23_162445) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_23_174401) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,12 +62,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_23_162445) do
   end
 
   create_table "jobs", force: :cascade do |t|
-    t.string "company_name"
+    t.string "board"
     t.string "title"
     t.string "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "employer"
     t.string "location"
     t.text "html_content"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_23_100719) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_23_162445) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,7 +43,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_23_100719) do
   end
 
   create_table "job_shows", force: :cascade do |t|
-    t.string "company"
+    t.string "board"
     t.string "url"
     t.string "script"
     t.datetime "created_at", null: false

--- a/spec/factories/job_shows.rb
+++ b/spec/factories/job_shows.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :JobShow do
-    company { Faker::Company.name }
+    board { Faker::Company.name }
     url { Faker::Internet.url }
     script { 'ShowPageScript' }
   end

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :job do
-    company_name { 'Big Company Inc' }
+    board { 'Big Company Inc' }
     title { 'Head of ticketing' }
     url { 'bigcompany.com/job' }
   end

--- a/spec/sidekiq/scrape_show_spec.rb
+++ b/spec/sidekiq/scrape_show_spec.rb
@@ -18,7 +18,16 @@ RSpec.describe ScrapeShow, type: :job do
   include ActiveSupport::Testing::TimeHelpers
 
   describe '#perform' do
-    let(:attributes) { OpenStruct.new(company_name: 'Job Board', url: 'url', title: 'Ticketing Manager', employer: "NVS", location: "London", html_content: "<p>Hello World</p>" ) }
+    let(:attributes) do
+      OpenStruct.new(
+        board: 'Job Board',
+        url: 'url',
+        title: 'Ticketing Manager',
+        employer: 'NVS',
+        location: 'London',
+        html_content: '<p>Hello World</p>'
+      )
+    end
     let(:script) { ShowPageScript }
     let(:job_show) { create(:JobShow) }
 

--- a/spec/sidekiq/scrape_show_spec.rb
+++ b/spec/sidekiq/scrape_show_spec.rb
@@ -18,45 +18,45 @@ RSpec.describe ScrapeShow, type: :job do
   include ActiveSupport::Testing::TimeHelpers
 
   describe '#perform' do
-    let(:attributes) do
+    let(:attributes) {
       OpenStruct.new(
         board: 'Job Board',
-        url: 'url',
+        url: 'www.exmaple.com',
         title: 'Ticketing Manager',
-        employer: 'NVS',
         location: 'London',
-        html_content: '<p>Hello World</p>'
+        html_content: '<p>Hello World</p>',
+        employer: 'Big Company inc'
       )
-    end
+    }
+
     let(:script) { ShowPageScript }
     let(:job_show) { create(:JobShow) }
 
     before { allow(script).to receive(:call).and_return(attributes) }
 
-    context 'when given attributes of a new job' do
-      it 'creates a new job record' do
+    context 'when given attributes of a job' do
+      it 'creates a new job record if the URL is new' do
         expect { subject.perform(job_show.id) }
           .to change(Job, :count).by(1)
 
         expect(Job.last).to have_attributes(
-          company_name: attributes.company_name,
+          board: attributes.board,
           url: attributes.url,
           title: attributes.title,
-          employer: attributes.employer,
           location: attributes.location,
           html_content: attributes.html_content
         )
       end
 
-      describe 'when give attributes of an existing job' do
-        it 'finds and updates the job' do
-          travel_to(1.month.ago)
-          Job.create(company_name: 'job record', title: 'that exists already', url: 'url')
-          travel_back
+      it 'finds and updates the job if the URL belongs a job' do
+        Job.create(
+          board: 'job record',
+          title: 'that exists already',
+          url: 'www.exmaple.com'
+        )
 
-          expect { subject.perform(job_show.id) }
-            .to change(Job, :count).by(0)
-        end
+        expect { subject.perform(job_show.id) }
+          .to change(Job, :count).by(0)
       end
     end
   end


### PR DESCRIPTION
In this PR, we prepare the JobShow and Job models for the upcoming addition of a new Employer model.

Firstly, we rename the company/company_name columns to board, which better represents what the data in these columns holds. e.g. the job board where the job is posted. 

In some cases, this will be the employer's website; in others, it will be a third-party jobs board. 

We also remove the employer string column from the Job model since we'll be associating jobs with the new Employer model shortly.

Finally, we update any views/logic to reference board.