### PR TITLE
Add employer model

### DIFF
--- a/app/models/employer.rb
+++ b/app/models/employer.rb
@@ -1,0 +1,2 @@
+class Employer < ApplicationRecord
+end

--- a/app/models/employer.rb
+++ b/app/models/employer.rb
@@ -1,2 +1,3 @@
 class Employer < ApplicationRecord
+  has_one_attached :logo
 end

--- a/app/models/employer.rb
+++ b/app/models/employer.rb
@@ -1,3 +1,6 @@
 class Employer < ApplicationRecord
   has_one_attached :logo
+  has_many :jobs
+
+  validates :name, presence: true
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,4 +1,6 @@
 class Job < ApplicationRecord
+  belongs_to :employer
+
   has_many :job_users  # Association with the join table
   has_many :users, through: :job_users # Many-to-many association through JobUser
 end

--- a/app/services/save_job.rb
+++ b/app/services/save_job.rb
@@ -4,6 +4,7 @@
 class SaveJob
   def self.call(attributes)
     job = Job.find_or_create_by(url: attributes.url)
+    employer = Employer.find_or_create_by(name: attributes.employer)
 
     # Update with latest attributes
     job.update(
@@ -11,7 +12,8 @@ class SaveJob
       url: attributes.url,
       title: attributes.title,
       location: attributes.location,
-      html_content: attributes.html_content
+      html_content: attributes.html_content,
+      employer:
     )
   end
 end

--- a/db/migrate/20250223130825_create_employer.rb
+++ b/db/migrate/20250223130825_create_employer.rb
@@ -1,0 +1,9 @@
+class CreateEmployer < ActiveRecord::Migration[7.2]
+  def change
+    create_table :employers do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250223130849_add_employer_to_jobs.rb
+++ b/db/migrate/20250223130849_add_employer_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddEmployerToJobs < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :jobs, :employer, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,6 +42,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_23_174401) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "employers", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "job_shows", force: :cascade do |t|
     t.string "board"
     t.string "url"
@@ -69,6 +75,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_23_174401) do
     t.datetime "updated_at", null: false
     t.string "location"
     t.text "html_content"
+    t.bigint "employer_id"
+    t.index ["employer_id"], name: "index_jobs_on_employer_id"
   end
 
   create_table "jobs_users", id: false, force: :cascade do |t|
@@ -100,5 +108,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_23_174401) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "job_users", "jobs"
   add_foreign_key "job_users", "users"
+  add_foreign_key "jobs", "employers"
   add_foreign_key "sessions", "users"
 end

--- a/spec/factories/employers.rb
+++ b/spec/factories/employers.rb
@@ -1,5 +1,11 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :employer do
-    
+    name { Faker::Company.name }
+
+    trait :with_logo do
+      logo { Rack::Test::UploadedFile.new("app/assets/images/logos/default.jpg", "image/jpeg") }
+    end
   end
 end

--- a/spec/factories/employers.rb
+++ b/spec/factories/employers.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :employer do
+    
+  end
+end

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -1,7 +1,12 @@
 FactoryBot.define do
   factory :job do
-    board { 'Big Company Inc' }
-    title { 'Head of ticketing' }
+
     url { 'bigcompany.com/job' }
+    title { 'Head of ticketing' }
+    location { 'London' }
+    html_content { '<p>Job description</p>' }
+    board { 'Jobs board' }
+
+    employer { create(:employer) }
   end
 end

--- a/spec/sidekiq/scrape_show_spec.rb
+++ b/spec/sidekiq/scrape_show_spec.rb
@@ -44,7 +44,10 @@ RSpec.describe ScrapeShow, type: :job do
           url: attributes.url,
           title: attributes.title,
           location: attributes.location,
-          html_content: attributes.html_content
+          html_content: attributes.html_content,
+          employer: have_attributes(
+            name: attributes.employer
+          )
         )
       end
 
@@ -52,11 +55,30 @@ RSpec.describe ScrapeShow, type: :job do
         Job.create(
           board: 'job record',
           title: 'that exists already',
-          url: 'www.exmaple.com'
+          url: 'www.exmaple.com',
+          employer:
+          create(
+            :employer,
+            name: 'Big Company inc'
+          )
         )
 
         expect { subject.perform(job_show.id) }
           .to change(Job, :count).by(0)
+      end
+    end
+
+    context 'when given the name an employer' do
+      it 'create a new Employer record if it does not exist' do
+        expect { subject.perform(job_show.id) }
+          .to change(Employer, :count).by(1)
+      end
+
+      it 'does not create an Employer record if it does exist' do
+        Employer.create(name: 'Big Company inc')
+
+        expect { subject.perform(job_show.id) }
+          .to change(Employer, :count).by(0)
       end
     end
   end


### PR DESCRIPTION
In this PR, we add the Employer model, give it the ability to have a logo, and set up the associations between Employer and Job. 

The foreign key relationships between Employer and Job on the database level are nullable, allowing us to backfill the associations before changing the null constraint to false and enforcing it later.

The logo change follows our work in this commit to set up ActiveStorage and S3.
`https://github.com/JHarrison89/sidekiq-scraper-tailwind/pull/26`.

The model level associations are added in the final commit, along with some spec and factory changes that are required to make the specs work with these changes.