### PR TITLE
Add service objects to set employers and employer logos

### DIFF
--- a/app/services/save_job.rb
+++ b/app/services/save_job.rb
@@ -2,9 +2,8 @@
 
 # Ceates or updates a job record
 class SaveJob
-  def self.call(attributes)
+  def self.call(employer:, attributes:)
     job = Job.find_or_create_by(url: attributes.url)
-    employer = Employer.find_or_create_by(name: attributes.employer)
 
     # Update with latest attributes
     job.update(

--- a/app/services/set_employer.rb
+++ b/app/services/set_employer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Finds or creates an employer
+class SetEmployer
+  def self.call(name:, logo_url:)
+    employer = Employer.find_or_create_by(name:)
+
+    SetEmployerLogo.call(employer:, logo_url:) unless employer.logo.attached?
+
+    employer
+  end
+end

--- a/app/services/set_employer_logo.rb
+++ b/app/services/set_employer_logo.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'open-uri'
+
+# Attaches a logo to an employer
+class SetEmployerLogo
+  def self.call(employer:, logo_url:)
+    return if employer.logo.attached?
+
+    employer.logo.attach(
+      io: URI.open(logo_url),
+      filename: "#{employer.name.parameterize}.png",
+      content_type: 'image/png'
+    )
+  end
+end

--- a/app/sidekiq/scrape_show.rb
+++ b/app/sidekiq/scrape_show.rb
@@ -15,7 +15,13 @@ class ScrapeShow
     # Early return if script return nil
     return if attributes.nil?
 
-    # Find or create job record
-    SaveJob.call(attributes)
+    # Find or create an employer
+    employer = SetEmployer.call(
+      name: attributes.employer,
+      logo_url: attributes.logo_url
+    )
+
+    # Find or create a job
+    SaveJob.call(employer:, attributes:)
   end
 end

--- a/spec/services/save_job_spec.rb
+++ b/spec/services/save_job_spec.rb
@@ -1,20 +1,26 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe SaveJob, type: :model do
-  let(:attributes) { OpenStruct.new(board: 'Job Board', url: 'doorsopen/first_job', title: 'Ticketing Manager', employer: create(:employer), location: "London", html_content: "<p>Hello World</p>") }
-  describe 'when given new attributes' do
-    it 'creates a new job' do
-      expect { described_class.call(attributes) }
+RSpec.describe SaveJob do
+  context "when given new job URL" do
+    it "creates a new job" do
+
+      # Unpersisted job
+      job = build(:job)
+
+      expect { described_class.call(employer: job.employer, attributes: job) }
         .to change(Job, :count).by(1)
     end
   end
 
-  describe 'when given existing attributes' do
-    before { Job.create(board: 'Job Board', url: 'doorsopen/first_job', title: 'Ticketing Manager', employer: create(:employer), location: "London", html_content: "<p>Hello World</p>") }
-    it 'does not create a new job' do
-      expect { described_class.call(attributes) }
+  context "when given existing job URL" do
+    it "does not create a new job" do
+
+      # Persisted job
+      job = create(:job)
+
+      expect { described_class.call(employer: job.employer, attributes: job) }
         .to change(Job, :count).by(0)
     end
   end

--- a/spec/services/save_job_spec.rb
+++ b/spec/services/save_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SaveJob, type: :model do
-  let(:attributes) { OpenStruct.new(company_name: 'Job Board', url: 'doorsopen/first_job', title: 'Ticketing Manager', employer: "NVS", location: "London", html_content: "<p>Hello World</p>") }
+  let(:attributes) { OpenStruct.new(board: 'Job Board', url: 'doorsopen/first_job', title: 'Ticketing Manager', employer: create(:employer), location: "London", html_content: "<p>Hello World</p>") }
   describe 'when given new attributes' do
     it 'creates a new job' do
       expect { described_class.call(attributes) }
@@ -12,7 +12,7 @@ RSpec.describe SaveJob, type: :model do
   end
 
   describe 'when given existing attributes' do
-    before { Job.create(company_name: 'Job Board', url: 'doorsopen/first_job', title: 'Ticketing Manager', employer: "NVS", location: "London", html_content: "<p>Hello World</p>") }
+    before { Job.create(board: 'Job Board', url: 'doorsopen/first_job', title: 'Ticketing Manager', employer: create(:employer), location: "London", html_content: "<p>Hello World</p>") }
     it 'does not create a new job' do
       expect { described_class.call(attributes) }
         .to change(Job, :count).by(0)

--- a/spec/services/set_employer_logo_spec.rb
+++ b/spec/services/set_employer_logo_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SetEmployerLogo do
+  let(:logo_url) { 'http://example.com/logo.png' }
+  let(:fake_file) { StringIO.new('fake image data') }
+
+  before do
+    # Stub the network call to URI.open
+    allow(URI).to receive(:open).with(logo_url).and_return(fake_file)
+  end
+
+  context 'when employer has no logo attached' do
+    it 'attaches a logo' do
+      employer = create(:employer)
+
+      expect(employer.logo.attached?).to be_falsey
+
+      SetEmployerLogo.call(employer:, logo_url:)
+
+      expect(employer.logo.attached?).to be_truthy
+    end
+  end
+
+  context 'when the employer has a logo' do
+    it 'returns nil' do
+      employer = create(:employer, :with_logo)
+
+      expect(described_class.call(employer:, logo_url:))
+        .to be_nil
+    end
+  end
+end

--- a/spec/services/set_employer_spec.rb
+++ b/spec/services/set_employer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SetEmployer do
+  let(:logo_url) { 'http://example.com/logo.png' }
+
+  before { allow(SetEmployerLogo).to receive(:call) }
+
+  context 'when given the name of a new employer' do
+    let(:name) { 'New Company inc' }
+
+    it 'creates a Employer record' do
+      expect { described_class.call(name:, logo_url:) }
+        .to change(Employer, :count).by(1)
+    end
+  end
+
+  context 'when given the name of an existing employer' do
+    it 'does not create a Employer record' do
+      name = Employer.create(name: 'Big Company inc').name
+
+      expect { described_class.call(name:, logo_url:) }
+        .to change(Employer, :count).by(0)
+    end
+  end
+end

--- a/spec/sidekiq/scrape_show_spec.rb
+++ b/spec/sidekiq/scrape_show_spec.rb
@@ -18,67 +18,56 @@ RSpec.describe ScrapeShow, type: :job do
   include ActiveSupport::Testing::TimeHelpers
 
   describe '#perform' do
-    let(:attributes) {
-      OpenStruct.new(
-        board: 'Job Board',
-        url: 'www.exmaple.com',
-        title: 'Ticketing Manager',
-        location: 'London',
-        html_content: '<p>Hello World</p>',
-        employer: 'Big Company inc'
-      )
-    }
-
     let(:script) { ShowPageScript }
     let(:job_show) { create(:JobShow) }
 
-    before { allow(script).to receive(:call).and_return(attributes) }
+    # Unpersisted job record
+    let(:job) { build(:job, employer: create(:employer, :with_logo)) }
+
+    let(:attributes) do
+      OpenStruct.new(
+        board: job.board,
+        url: job.url,
+        title: job.title,
+        location: job.location,
+        html_content: job.html_content,
+        logo_url: 'http://example.com/logo.png',
+        employer: job.employer.name
+      )
+    end
+
+    let(:logo_url) { 'http://example.com/logo.png' }
+    let(:fake_file) { StringIO.new('fake image data') }
+
+    before do
+      # Stub the call to Script
+      allow(script).to receive(:call).and_return(attributes)
+
+      # Stub the network call to URI.open
+      allow(URI).to receive(:open).with(logo_url).and_return(fake_file)
+    end
 
     context 'when given attributes of a job' do
-      it 'creates a new job record if the URL is new' do
+      it 'creates a new job record if the URL does not belong to a job' do
         expect { subject.perform(job_show.id) }
           .to change(Job, :count).by(1)
 
         expect(Job.last).to have_attributes(
-          board: attributes.board,
-          url: attributes.url,
-          title: attributes.title,
-          location: attributes.location,
-          html_content: attributes.html_content,
-          employer: have_attributes(
-            name: attributes.employer
-          )
+          board: job.board,
+          title: job.title,
+          location: job.location,
+          html_content: job.html_content,
+          url: job.url,
+          employer: job.employer
         )
       end
 
-      it 'finds and updates the job if the URL belongs a job' do
-        Job.create(
-          board: 'job record',
-          title: 'that exists already',
-          url: 'www.exmaple.com',
-          employer:
-          create(
-            :employer,
-            name: 'Big Company inc'
-          )
-        )
+      it 'updates the job if the URL belongs an existing job' do
+        # Persisted job record
+        create(:job, employer: create(:employer, :with_logo))
 
         expect { subject.perform(job_show.id) }
           .to change(Job, :count).by(0)
-      end
-    end
-
-    context 'when given the name an employer' do
-      it 'create a new Employer record if it does not exist' do
-        expect { subject.perform(job_show.id) }
-          .to change(Employer, :count).by(1)
-      end
-
-      it 'does not create an Employer record if it does exist' do
-        Employer.create(name: 'Big Company inc')
-
-        expect { subject.perform(job_show.id) }
-          .to change(Employer, :count).by(0)
       end
     end
   end


### PR DESCRIPTION
In this PR, we add two new service objects. The first finds or creates an Employer, and the second attaches a logo to an instance of an Employer if none exists. 

They are each designed as simple service objects that can work independently.

Finally, we use these two new service objects to the scrape show script, which we use to scrape the details of a job from a show page and save the attributes as a job record. 

By adding the `SetEmployer` call, we ensure we set an employer with a logo in the process of creating or updating a Job record.