### PR TITLE
Scripts now return employer and logo url

### DIFF
--- a/app/services/show_pages/broadwick.rb
+++ b/app/services/show_pages/broadwick.rb
@@ -40,18 +40,24 @@ module ShowPages
             body = body.gsub("<ul>", '<ul class="list-outside list-disc text-gray-900 dark:text-gray-200">')
             body = body.gsub("<li>", '<li class="mt-2">')
 
+            # Extracting the employer details
+            # Logo added manually
+            employer = "Broadwick Live"
+            logo_url = nil
+
           ensure
             browser.quit
           end
 
           # Return object when successful
           return OpenStruct.new(
-            company_name: "Broadwick",
+            board: employer,
             url:,
             title:,
-            employer: "Broadwick",
             location:,
             html_content: body,
+            employer:,
+            logo_url:
           )
         else
           sleep rand(150)

--- a/app/services/show_pages/doors_open.rb
+++ b/app/services/show_pages/doors_open.rb
@@ -18,15 +18,14 @@ module ShowPages
         response = HTTParty.get(url)
 
         if response.code == 200
+
           # Parsing the HTML document returned by the server
           doc = Nokogiri::HTML(response.body)
 
           # Extracting the job details
           title = doc.css(".details-header__title").text.strip
-          employer = doc.css(".listing-item__info--item-company").text.strip
           location = doc.css(".listing-item__info--item-location").text.strip
           body = doc.css(".details-body__content").to_html
-
           body = Loofah.html5_fragment(body)
                        .scrub!(:prune)
                        .scrub!(:escape)
@@ -43,14 +42,19 @@ module ShowPages
           body = body.gsub("<ul>", '<ul class="list-outside list-disc text-gray-900 dark:text-gray-200">')
           body = body.gsub("<li>", '<li class="mt-2">')
 
+          # Extracting the employer details
+          employer = doc.css(".listing-item__info--item-company").text.strip
+          logo_url = doc.css(".sidebar__content").at("img")["src"]
+
           # Return object when successful
           return OpenStruct.new(
-            company_name: "Doors Open",
+            board: "Doors Open",
             url:,
             title:,
-            employer:,
             location:,
-            html_content: body
+            html_content: body,
+            employer:,
+            logo_url:
           )
         else
           sleep rand(300)

--- a/app/sidekiq/scrape_show.rb
+++ b/app/sidekiq/scrape_show.rb
@@ -9,7 +9,7 @@ class ScrapeShow
     # Instantiate object
     script = Object.const_get(record.script)
 
-    # Scrape webspage and return result
+    # Scrape webpage and return result
     attributes = script.call(record.url)
 
     # Early return if script return nil


### PR DESCRIPTION
In this PR, we update the show page scripts to return the `employer` and `logo_url`.  

These values are dynamic for the `DoorsOpen` script, but they are fixed and never change for the Broadwick Live script. 

In cases like this, we'll create the Employer manually at the same time we introduce the script so the Employer its set up and ready for when the script runs.