### PR TITLE
Posted at font color is no dynamic

### DIFF
--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -7,6 +7,6 @@
 </div>
 
 <p class="mt-1 text-sm leading-6 text-gray-600">A list of all the job posts from our list of job sites.</p>
-<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
 <%= render "shared/job_list", locals: { jobs: @jobs } %>

--- a/app/views/identity/emails/edit.html.erb
+++ b/app/views/identity/emails/edit.html.erb
@@ -7,7 +7,7 @@
     <p class="mt-1 text-sm leading-6 text-gray-600">We sent a verification email to the address below. Check that email and follow those instructions to confirm it's your email address.</p>
     <p><%= button_to "Re-send verification email", identity_email_verification_path %></p>
   <% end %>
-  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
   <% if @user.errors.any? %>
     <div class="rounded-md bg-red-50 p-4 mb-10">
       <div class="flex">
@@ -41,7 +41,7 @@
       </div>
     </div>
   </div>
-  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
   <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
     <div>
       <%= form.label :password_challenge, style: "display: block", class: "block text-sm font-medium leading-6 text-gray-900" %>

--- a/app/views/job/rejects/index.html.erb
+++ b/app/views/job/rejects/index.html.erb
@@ -7,6 +7,6 @@
 </div>
 
 <p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've rejected.</p>
-<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
 <%= render "shared/job_list", locals: { jobs: @jobs } %>

--- a/app/views/job/saves/index.html.erb
+++ b/app/views/job/saves/index.html.erb
@@ -7,6 +7,6 @@
 </div>
 
 <p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've saved.</p>
-<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
 <%= render "shared/job_list", locals: { jobs: @jobs } %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -33,6 +33,6 @@
   </div>
 </div>
 
-<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
 <%= @job.html_content.html_safe %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(url: password_path, method: :patch) do |form| %>
   <h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white">Edit password</h1>
-  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
   <% if @user.errors.any? %>
     <div class="rounded-md bg-red-50 p-4 mb-10">
       <div class="flex">
@@ -33,7 +33,7 @@
       </div>
     </div>
   </div>
-  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+  <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
   <div class="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
     <div>
       <%= form.label :password, "New password", style: "display: block", class: "block text-sm font-medium leading-6 text-gray-900" %>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white">Devices & Sessions</h1>
 <p class="mt-2 text-sm text-gray-700">A list of all the devices signed into your account.</p>
-<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10 dark:border-white/10">
+<hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 <div class="mt-8 flow-root overflow-hidden">
   <table class="w-full text-left">
     <thead class="bg-white">

--- a/app/views/shared/_job_list.html.erb
+++ b/app/views/shared/_job_list.html.erb
@@ -4,7 +4,7 @@
 
 
       <div class="job-list">
-        <p class="mt-1 text-2xl/8 font-semibold sm:text-xl/8 dark:text-white">Posted <%= date.to_s.humanize.downcase %></p>
+        <p class="mt-1 text-2xl/8 text-gray-900 font-semibold sm:text-xl/8">Posted <%= date.to_s.humanize.downcase %></p>
         <% jobs.each do |job| %>
             <%= link_to job_path(job) do %>
               <li class="relative flex justify-between gap-x-6 py-5">


### PR DESCRIPTION
In this PR, we remove the dynamic device color detection from the tailwind markup for the `<hr>` border tag and the grouped by date headers e.g Posted x days ago".

Without these changes, these elements would sometimes not be visible depending on the device system color. 