### PR TITLE
Update job list and show layouts

### DIFF
--- a/app/views/jobs/_status.html.erb
+++ b/app/views/jobs/_status.html.erb
@@ -8,8 +8,8 @@
       Rejected
     </span>
   <% else %>
-    <span class="rounded-md bg-grey-50 px-2 py-1 text-xs font-medium text-grey-700 ring-1 ring-inset ring-grey-600/20">
-      unsaved
+    <span class="rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-600/20">
+      Unsaved
     </span>
   <% end %>
 </div>

--- a/app/views/jobs/_status.html.erb
+++ b/app/views/jobs/_status.html.erb
@@ -7,5 +7,9 @@
     <span class="rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-inset ring-red-600/20">
       Rejected
     </span>
+  <% else %>
+    <span class="rounded-md bg-grey-50 px-2 py-1 text-xs font-medium text-grey-700 ring-1 ring-inset ring-grey-600/20">
+      unsaved
+    </span>
   <% end %>
 </div>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -1,36 +1,32 @@
 
 
 
-<div class="pb-0">
-  <%= render "action", job: @job, status: @status %>
-</div>
+<div class="relative flex justify-between gap-x-6 py-5">
+  <div>
+    <h1 class="text-2xl font-semibold leading-6 text-gray-900 ">
+      <%= @job.title %>
+    </h1>
+    <div class="[&>*]:leading-5 [&>*]:mt-1">
+      <p>
+        <%= @job.employer.name %>
+      </p>
+      <p>
+        <%= @job.location %>
+      </p>
+      <p class="text-xs leading-5 text-gray-500">
+        Posted <%= @job.created_at.strftime("%-d %b, %Y, %-l:%M%P") %>
+      </p>
+    </div>
+  </div>
 
-<div class="flex gap-x-4 py-6 w-full">
-  <img class="h-12 w-12 flex-none rounded-full bg-gray-50" src="<%= employer_logo_helper(employer: @job.employer) %>" alt="">
-  <div class="flex items-center">
-    <h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white"><%= @job.title %></h1>
+  <div class="flex items-center justify-center">
+    <img class="h-20 object-scale-down" src="<%= employer_logo_helper(employer: @job.employer) %>" alt="">
   </div>
 </div>
 
 <div class="flex justify-between">
-  <div class="flex-auto">
-    <div class="flex items-start gap-x-3">
-      <div class="text-sm/6 font-medium text-gray-900"> <%= @job.employer.name %></div>
-      <%= render "status", status: @status %>
-    </div>
-    <div class="mt-1 text-xs/5 text-gray-500"><%= @job.location %></div>
-  </div>
-
-
-  <div class="text-right">
-    <div class="flex justify-end">
-
-      <%= link_to "View", @job.url, class: "text-sm/6 font-medium text-indigo-600 hover:text-indigo-500"%>
-
-      <span class="sr-only">, invoice #00012, Reform</span></a>
-    </div>
-    <div class="mt-1 text-xs/5 text-gray-500">Posted <%= @job.created_at.strftime("%-d %b, %Y, %-l:%M%P") %></div>
-  </div>
+  <%= render "status", status: @status %>
+  <%= render "action", job: @job, status: @status %>
 </div>
 
 <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">

--- a/app/views/shared/_job_list.html.erb
+++ b/app/views/shared/_job_list.html.erb
@@ -9,7 +9,9 @@
             <%= link_to job_path(job) do %>
               <li class="relative flex justify-between gap-x-6 py-5">
                 <div class="flex min-w-0 gap-x-4">
-                  <img class="h-12 w-12 flex-none rounded-full bg-gray-50" src="<%= employer_logo_helper(employer: job.employer) %>" alt="">
+                  <div class="flex h-12 w-12 rounded-full">
+                    <img class="rounded-full object-scale-down" src="<%= employer_logo_helper(employer: job.employer) %>" alt="">
+                  </div>
                   <div class="min-w-0 flex-auto">
                     <p class="text-sm font-semibold leading-6 text-gray-900">
                         <span class="absolute inset-x-0 -top-px bottom-0"></span>

--- a/app/views/shared/_job_list.html.erb
+++ b/app/views/shared/_job_list.html.erb
@@ -15,14 +15,17 @@
                         <span class="absolute inset-x-0 -top-px bottom-0"></span>
                         <%= job.title%>
                     </p>
-                    <p class="mt-1 flex text-xs leading-5 text-gray-500">
-                      <%= job.board %>
+                    <p class="mt-1 flex text-xs leading-5 text-gray-500 items-center">
+                      <%= job.employer.name %>
                     </p>
                   </div>
                 </div>
                 <div class="flex shrink-0 items-center gap-x-4">
                   <div class="hidden sm:flex sm:flex-col sm:items-end">
-                    <p class="text-sm leading-6 text-gray-900"></p>
+                    <p class="flex mt-1 text-xs leading-5 text-gray-500 text-left gap-x-4 w-full">
+                      <img class="h-5 w-5 flex-none rounded-full bg-gray-50" src="<%= board_logo_helper(board: job.board) %>" alt="">
+                      <%= job.board %>
+                    </p>
                     <p class="mt-1 text-xs leading-5 text-gray-500">Posted <%= job.created_at.strftime("%-d %b, %Y, %-l:%M%P") %></p>
                   </div>
                   <svg class="h-5 w-5 flex-none text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">


### PR DESCRIPTION
This PR updates the layout of the job list partial so that each job (row) now displays the employer name and board logo on the right side.

We also update the layout of the job shoe page to make it more visually appealing by giving the job title more prominence and adding the employer logo to the right of the title to balance the layout.

The job status section is moved from the top of the page to under the job title and employer name,  and we update the job status partial to include a status for unsaved jobs, which is the default for any job that has not been saved/rejected.

This means we'll always show a status badge for every job, which helps to balance our layout and encourages users to click the save/reject buttons.