### PR TITLE
Lock Tailwind gems to Tailwind V3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,8 +96,10 @@ end
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"
 
+# pin to tailwindcss-rails version 3.3.1
 gem "tailwindcss-rails", "~> 3.3.1"
-# pin to tailwindcss version 3.4.13
+
+# pin to tailwindcss version 3.4.17
 gem "tailwindcss-ruby", "3.4.17"
 
 # Make avaible to production & development

--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,9 @@ end
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"
 
-gem "tailwindcss-rails"
+gem "tailwindcss-rails", "~> 3.3.1"
+# pin to tailwindcss version 3.4.13
+gem "tailwindcss-ruby", "3.4.17"
 
 # Make avaible to production & development
 gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,7 +404,8 @@ DEPENDENCIES
   sidekiq (~> 7.2)
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails
+  tailwindcss-rails (~> 3.3.1)
+  tailwindcss-ruby (= 3.4.17)
   turbo-rails
   tzinfo-data
   watir


### PR DESCRIPTION
Since Tailwind 4 has been released, we lock the Tailwind gems to V3 versions to prevent them from being accidentally updated.

I spent some time trying to get Tailwind 4 working, which should be possible given how simple the Tailwind setup/configuration is in this project. However, it didn't seem like a sensible investment of time given the additional features (filtering job lists, tagging jobs and CVs with DeepSeek) that I want to work on, so this project is ready to show to recruiters.