### PR TITLE
Restore client for AWS in LogoHelper

### DIFF
--- a/app/helpers/logo_helper.rb
+++ b/app/helpers/logo_helper.rb
@@ -8,6 +8,14 @@ module LogoHelper
   # TODO: Create a Board model and store board logos in the database
   #
   class FetchImage
+    def self.client
+      Aws::S3::Client.new(
+        region: "eu-north-1",
+        access_key_id: Rails.application.credentials.dig(:aws, :access_key_id),
+        secret_access_key: Rails.application.credentials.dig(:aws, :secret_access_key)
+      )
+    end
+
     def self.presigned_url(key:)
       signer = Aws::S3::Presigner.new(client:)
 


### PR DESCRIPTION
I mistakenly removed the client method from the LogoHelper class in a recent commit. Since we stub the AWS method calls in the spec, the tests still passed which highlights that I need to improve the spec coverage here.