### PR TITLE
Refactor job list partial parameter format

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -15,7 +15,7 @@ class AccountsController < ApplicationController
     @employers = jobs.map(&:employer).uniq
 
     # Groups jobs by created_at date
-    @jobs = RecordGrouper.call(jobs)
+    @grouped_jobs = GroupRecordsByDate.call(jobs)
 
     respond_to do |format|
       # Use turbo_stream if filters are present

--- a/app/controllers/job/rejects_controller.rb
+++ b/app/controllers/job/rejects_controller.rb
@@ -7,7 +7,7 @@ class Job::RejectsController < ApplicationController
 
   def index
     jobs = Current.user.jobs.where(job_users: { status: :rejected })
-    @jobs = RecordGrouper.call(jobs)
+    @grouped_jobs = GroupRecordsByDate.call(jobs)
   end
 
   def update

--- a/app/controllers/job/saves_controller.rb
+++ b/app/controllers/job/saves_controller.rb
@@ -7,7 +7,7 @@ class Job::SavesController < ApplicationController
 
   def index
     jobs = Current.user.jobs.where(job_users: { status: :saved })
-    @jobs = RecordGrouper.call(jobs)
+    @grouped_jobs = GroupRecordsByDate.call(jobs)
   end
 
   def update

--- a/app/services/group_records_by_date.rb
+++ b/app/services/group_records_by_date.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Used to group records by creation date, e.g job records
-class RecordGrouper
+class GroupRecordsByDate
   def self.call(records)
     grouped = {
       today: [],

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -10,4 +10,4 @@
 <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
 <%= render "filter", employers: @employers %>
-<%= render "shared/job_list", locals: { jobs: @jobs } %>
+<%= render "shared/job_list", jobs: @jobs %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -10,4 +10,4 @@
 <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
 <%= render "filter", employers: @employers %>
-<%= render "shared/job_list", jobs: @jobs %>
+<%= render "shared/job_list", grouped_jobs: @grouped_jobs %>

--- a/app/views/accounts/show.turbo_stream.erb
+++ b/app/views/accounts/show.turbo_stream.erb
@@ -5,5 +5,5 @@
 <% end %>
 
 <%= turbo_stream.replace "job_list" do %>
-  <%= render "shared/job_list", jobs: @jobs %>
+  <%= render "shared/job_list", grouped_jobs: @grouped_jobs %>
 <% end %>

--- a/app/views/accounts/show.turbo_stream.erb
+++ b/app/views/accounts/show.turbo_stream.erb
@@ -5,5 +5,5 @@
 <% end %>
 
 <%= turbo_stream.replace "job_list" do %>
-  <%= render "shared/job_list", locals: { jobs: @jobs } %>
+  <%= render "shared/job_list", jobs: @jobs %>
 <% end %>

--- a/app/views/job/rejects/index.html.erb
+++ b/app/views/job/rejects/index.html.erb
@@ -9,4 +9,4 @@
 <p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've rejected.</p>
 <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
-<%= render "shared/job_list", locals: { jobs: @jobs } %>
+<%= render "shared/job_list", jobs: @jobs %>

--- a/app/views/job/rejects/index.html.erb
+++ b/app/views/job/rejects/index.html.erb
@@ -9,4 +9,4 @@
 <p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've rejected.</p>
 <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
-<%= render "shared/job_list", jobs: @jobs %>
+<%= render "shared/job_list", grouped_jobs: @grouped_jobs %>

--- a/app/views/job/saves/index.html.erb
+++ b/app/views/job/saves/index.html.erb
@@ -9,4 +9,4 @@
 <p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've saved.</p>
 <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
-<%= render "shared/job_list", jobs: @jobs %>
+<%= render "shared/job_list", grouped_jobs: @grouped_jobs %>

--- a/app/views/job/saves/index.html.erb
+++ b/app/views/job/saves/index.html.erb
@@ -9,4 +9,4 @@
 <p class="mt-1 text-sm leading-6 text-gray-600">A list of the jobs you've saved.</p>
 <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 
-<%= render "shared/job_list", locals: { jobs: @jobs } %>
+<%= render "shared/job_list", jobs: @jobs %>

--- a/app/views/shared/_job_list.html.erb
+++ b/app/views/shared/_job_list.html.erb
@@ -1,9 +1,7 @@
 <%= turbo_frame_tag "job_list" do %>
   <ul role="list" class="divide-y divide-gray-100">
     <div class="flex flex-col space-y-8">
-      <% @jobs.each do |date, jobs| %>
-
-
+      <% jobs.each do |date, jobs| %>
         <div class="job-list">
           <p class="mt-1 text-2xl/8 text-gray-900 font-semibold sm:text-xl/8">Posted <%= date.to_s.humanize.downcase %></p>
           <% jobs.each do |job| %>

--- a/app/views/shared/_job_list.html.erb
+++ b/app/views/shared/_job_list.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "job_list" do %>
   <ul role="list" class="divide-y divide-gray-100">
     <div class="flex flex-col space-y-8">
-      <% jobs.each do |date, jobs| %>
+      <% grouped_jobs.each do |date, jobs| %>
         <div class="job-list">
           <p class="mt-1 text-2xl/8 text-gray-900 font-semibold sm:text-xl/8">Posted <%= date.to_s.humanize.downcase %></p>
           <% jobs.each do |job| %>

--- a/spec/services/record_grouper_spec.rb
+++ b/spec/services/record_grouper_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe RecordGrouper, type: :model do
+RSpec.describe GroupRecordsByDate, type: :model do
   let(:grouped_records) { described_class.call(Job.all) }
 
   it "groups records created today" do


### PR DESCRIPTION
In this PR, we change how we pass parameters into the job list partial to use the correct format and rename the `GroupRecords` service object to `GroupRecordsByDate,` which is much more descriptive.  

We also take this opportunity to update the instance variables we create with the service object from `@jobs` to `@grouped_jobs` for clarity. 