### PR TITLE
Update headers on password email and session views

### DIFF
--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-10 bg-gradient-to-r from-violet-600 to-indigo-600 rounded-lg shadow">
   <div class="flex min-w-0 gap-x-4 px-4 py-5 sm:p-6">
     <div class="min-w-0 flex-auto">
-    <h1 class="text-2xl/8 font-semibold text-white sm:text-xl/8 dark:text-white">All jobs</h1>
+    <h1 class="font-semibold text-white sm:text-xl/8">All jobs</h1>
     </div>
   </div>
 </div>

--- a/app/views/identity/emails/edit.html.erb
+++ b/app/views/identity/emails/edit.html.erb
@@ -1,11 +1,13 @@
 
 <%= form_with(url: identity_email_path, method: :patch) do |form| %>
   <% if Current.user.verified? %>
-    <h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white">Change your email</h1>
+    <h1 class="font-semibold sm:text-xl/8 leading-6 text-gray-900">Change your email</h1>
   <% else %>
-    <h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white">Verify your email</h1>
-    <p class="mt-1 text-sm leading-6 text-gray-600">We sent a verification email to the address below. Check that email and follow those instructions to confirm it's your email address.</p>
-    <p><%= button_to "Re-send verification email", identity_email_verification_path %></p>
+    <h1 class="font-semibold sm:text-xl/8 leading-6 text-gray-900">Verify your email</h1>
+    <p class="mt-1 text-sm leading-6 text-gray-600">We sent a verification email to the address below.</p>
+        <p class="mt-1 text-sm leading-6 text-gray-600">Check that email and follow those instructions to confirm it's your email address.</p>
+
+    <p><%= button_to "Re-send verification email", identity_email_verification_path, class: "mt-3 rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %></p>
   <% end %>
   <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
   <% if @user.errors.any? %>

--- a/app/views/job/rejects/index.html.erb
+++ b/app/views/job/rejects/index.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-10 bg-gradient-to-r from-violet-600 to-indigo-600 rounded-lg shadow">
   <div class="flex min-w-0 gap-x-4 px-4 py-5 sm:p-6">
     <div class="min-w-0 flex-auto">
-    <h1 class="text-2xl/8 font-semibold text-white sm:text-xl/8 dark:text-white">Rejected jobs</h1>
+    <h1 class="font-semibold text-white sm:text-xl/8">Rejected jobs</h1>
     </div>
   </div>
 </div>

--- a/app/views/job/saves/index.html.erb
+++ b/app/views/job/saves/index.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-10 bg-gradient-to-r from-violet-600 to-indigo-600 rounded-lg shadow">
   <div class="flex min-w-0 gap-x-4 px-4 py-5 sm:p-6">
     <div class="min-w-0 flex-auto">
-    <h1 class="text-2xl/8 font-semibold text-white sm:text-xl/8 dark:text-white">Saved jobs</h1>
+    <h1 class="font-semibold text-white sm:text-xl/8">Saved jobs</h1>
     </div>
   </div>
 </div>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,5 +1,6 @@
 <%= form_with(url: password_path, method: :patch) do |form| %>
-  <h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white">Edit password</h1>
+  <h1 class="font-semibold sm:text-xl/8 leading-6 text-gray-900">Change your password</h1>
+  <p class="mt-2 text-sm text-gray-700">Change your password using the form below.</p>
   <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
   <% if @user.errors.any? %>
     <div class="rounded-md bg-red-50 p-4 mb-10">

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white">Devices & Sessions</h1>
+<h1 class="font-semibold sm:text-xl/8 leading-6 text-gray-900">Devices & Sessions</h1>
 <p class="mt-2 text-sm text-gray-700">A list of all the devices signed into your account.</p>
 <hr role="presentation" class="my-10 mt-6 w-full border-t border-zinc-950/10">
 <div class="mt-8 flow-root overflow-hidden">


### PR DESCRIPTION
In this PR, we update the headers on the password, email, and session views to ensure they are always showing and the sizing and font colours are constant across the platform. 

We also remove unnecessary classes from the headers on the account, as well as saved and rejected views. 