### PR TITLE
Scripts have sleep time parameter

### DIFF
--- a/app/services/show_pages/broadwick.rb
+++ b/app/services/show_pages/broadwick.rb
@@ -7,12 +7,12 @@ module ShowPages
   # Scraps a webpage and returns
   # an object with job attributes
   class Broadwick
-    def self.call(url)
+    def self.call(url, sleep_time = 120)
       attempts = 0
       max_attempts = 3
 
       while attempts < max_attempts
-        sleep rand(120)
+        sleep rand(sleep_time)
         browser = Ferrum::Browser.new(browser_options: { 'no-sandbox': nil })
         browser.goto(url)
 
@@ -59,7 +59,7 @@ module ShowPages
             logo_url:
           )
         else
-          sleep rand(150)
+          sleep rand(sleep_time)
           attempts += 1
         end
       end

--- a/app/services/show_pages/doors_open.rb
+++ b/app/services/show_pages/doors_open.rb
@@ -7,13 +7,13 @@ module ShowPages
   # Scraps a webpage and returns
   # an object with job attributes
   class DoorsOpen
-    def self.call(url)
+    def self.call(url, sleep_time = 200)
       attempts = 0
       max_attempts = 3
 
       while attempts < max_attempts
         # Avoiding being blocked
-        sleep rand(200)
+        sleep rand(sleep_time)
 
         response = HTTParty.get(url)
 

--- a/app/sidekiq/scrape_show.rb
+++ b/app/sidekiq/scrape_show.rb
@@ -3,14 +3,14 @@
 class ScrapeShow
   include Sidekiq::Job
 
-  def perform(id)
+  def perform(id, sleep_time = 200)
     record = JobShow.find(id)
 
     # Instantiate object
     script = Object.const_get(record.script)
 
     # Scrape webpage and return result
-    attributes = script.call(record.url)
+    attributes = script.call(record.url, sleep_time)
 
     # Early return if script return nil
     return if attributes.nil?

--- a/spec/sidekiq/scrape_show_spec.rb
+++ b/spec/sidekiq/scrape_show_spec.rb
@@ -8,12 +8,14 @@ require "sidekiq/testing"
 # show page of a site
 # e.g doorsopen.com
 class ShowPageScript
-  def self.call(url); end
+  def self.call(url, sleep_time); end
 end
 
 # Tests the show page job. The call to the
 # show page script is stubs to avoid calling
 # out to a real website.
+#
+# TODO: Update test to include sleep_time argument
 RSpec.describe ScrapeShow, type: :job do
   include ActiveSupport::Testing::TimeHelpers
 
@@ -50,7 +52,7 @@ RSpec.describe ScrapeShow, type: :job do
 
     context "when given attributes of a job" do
       it "creates a new job record if the URL does not belong to a job" do
-        expect { subject.perform(job_show.id) }
+        expect { subject.perform(job_show.id, 10) }
           .to change(Job, :count).by(1)
 
         expect(Job.last).to have_attributes(


### PR DESCRIPTION
This will allow us to controll the amount of time the scripts sleep for when scraping a a page. The current defaults are taking too long and since we need to backfill the existing job recods with Employers and Boards by re-running the scripts on evey job, this seems like the best option.