### PR TITLE
Update sleep time if the request fails

### DIFF
--- a/app/services/show_pages/doors_open.rb
+++ b/app/services/show_pages/doors_open.rb
@@ -57,7 +57,7 @@ module ShowPages
             logo_url:
           )
         else
-          sleep rand(300)
+          sleep rand(sleep_time)
           attempts += 1
         end
       end


### PR DESCRIPTION
Some of these URLs we're trying to backfill are no longer available, so they return a 404 and move the script into the else block. We need to update the timer here so we don't wait for a long time before trying again, and eventually quitting after 3 attempts.

Follow on from https://github.com/JHarrison89/sidekiq-scraper-tailwind/pull/45